### PR TITLE
bugfix: fix to the network interfaces loop

### DIFF
--- a/build/testardo
+++ b/build/testardo
@@ -74,6 +74,8 @@ function grabJSContent(libraries) {
 var
   global = this,
   COMMON_DELAY = 100,
+  // Set a nicer custom font for the output
+  GOOGLE_FONT = '<link href=\'http://fonts.googleapis.com/css?family=Ubuntu\' rel=\'stylesheet\' type=\'text/css\'>',
   // use native selector or not ?
   NATIVE_SELECTOR = !!global.document.querySelectorAll,
   // try to understand the current page width
@@ -281,16 +283,22 @@ function removeListener(where, which, what, lvl0) {
 // show a big green or red page accordingly with tests result
 function showResult(text) {
   var
-    innerHTML = '<center><b>' + text + '</b></center>',
+    innerHTML = GOOGLE_FONT,
     html
   ;
+
+  innerHTML += '<center><b>' + text + '</b></center>';
   try {
     (html = global.document.documentElement).innerHTML = innerHTML;
   } catch(probablyIE9Mobile) {
     (html = document.body).innerHTML = innerHTML;
   }
-  html.style.background = text == 'OK' ? '#0F0' : (
-    text === 'offline' ? '#FF0' : '#F00'
+  // a bit of styling
+  html.style.fontFamily = '\'Ubuntu\', Arial, sans-serif';
+  html.style.fontSize = '3.5em';
+
+  html.style.background = text == 'OK' ? '#62b81d' : (
+    text === 'offline' ? '#fff000' : '#d9313b'
   );
 }
 

--- a/build/testardo
+++ b/build/testardo
@@ -1031,19 +1031,20 @@ function server(req, response){
         show = [];
     Object.keys(interfaces).forEach(
       function(key){
-        interfaces[key].forEach(this, key);
+        interfaces[key].forEach(this, [key]);
       },
       function(obj){
+        var networkwInterface = this[0];
         if (
           // not an internal interface
           !obj.internal &&
           // right now easier to reach through the network/url bar
           obj.family === 'IPv4' &&
           // either WiFi in Mac or Linux
-          /^en[1-9]\d*|wlan\d+$/.test(this)
+          /^en[0-9]\d*|wlan\d+$/.test(networkwInterface)
         ) {
           // put this as possible reachable url for testing
-          show.push(this + ': http://' + obj.address + ':' + (PORT - 1) + '/$');
+          show.push(networkwInterface + ': http://' + obj.address + ':' + (PORT - 1) + '/$');
         }
       }
     );

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -3,6 +3,8 @@
 var
   global = this,
   COMMON_DELAY = 100,
+  // Set a nicer custom font for the output
+  GOOGLE_FONT = '<link href=\'http://fonts.googleapis.com/css?family=Ubuntu\' rel=\'stylesheet\' type=\'text/css\'>',
   // use native selector or not ?
   NATIVE_SELECTOR = !!global.document.querySelectorAll,
   // try to understand the current page width
@@ -210,16 +212,22 @@ function removeListener(where, which, what, lvl0) {
 // show a big green or red page accordingly with tests result
 function showResult(text) {
   var
-    innerHTML = '<center><b>' + text + '</b></center>',
+    innerHTML = GOOGLE_FONT,
     html
   ;
+
+  innerHTML += '<center><b>' + text + '</b></center>';
   try {
     (html = global.document.documentElement).innerHTML = innerHTML;
   } catch(probablyIE9Mobile) {
     (html = document.body).innerHTML = innerHTML;
   }
-  html.style.background = text == 'OK' ? '#0F0' : (
-    text === 'offline' ? '#FF0' : '#F00'
+  // a bit of styling
+  html.style.fontFamily = '\'Ubuntu\', Arial, sans-serif';
+  html.style.fontSize = '3.5em';
+
+  html.style.background = text == 'OK' ? '#62b81d' : (
+    text === 'offline' ? '#fff000' : '#d9313b'
   );
 }
 

--- a/src/server/runner.js
+++ b/src/server/runner.js
@@ -7,19 +7,20 @@
         show = [];
     Object.keys(interfaces).forEach(
       function(key){
-        interfaces[key].forEach(this, key);
+        interfaces[key].forEach(this, [key]);
       },
       function(obj){
+        var networkwInterface = this[0];
         if (
           // not an internal interface
           !obj.internal &&
           // right now easier to reach through the network/url bar
           obj.family === 'IPv4' &&
           // either WiFi in Mac or Linux
-          /^en[1-9]\d*|wlan\d+$/.test(this)
+          /^en[0-9]\d*|wlan\d+$/.test(networkwInterface)
         ) {
           // put this as possible reachable url for testing
-          show.push(this + ': http://' + obj.address + ':' + (PORT - 1) + '/$');
+          show.push(networkwInterface + ': http://' + obj.address + ':' + (PORT - 1) + '/$');
         }
       }
     );


### PR DESCRIPTION
I have fixed a bug affecting the webinterfaces loop. The previous was using the 'this' context in the wrong way. The forEach method needs an array of arguments https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
